### PR TITLE
More arguments to console app

### DIFF
--- a/app.py
+++ b/app.py
@@ -82,7 +82,17 @@ def parse_args(argv):
     )
     parser.add_argument(
         '--path',
-        help='A path to a folder or image is required e.g /hotels or newhotel.jpg'
+        help='A path to a folder or image(optional) e.g /hotels or newhotel.jpg'
+    )
+    parser.add_argument(
+        '-trp',
+        '--train_folder_path',
+        help = 'A training folder path e.g dataset/training_set'
+    )
+    parser.add_argument(
+        '-tep',
+        '--test_folder_path',
+        help = 'A test folder path e.g dataset/test_set'
     )
     return parser.parse_args(argv[1:])
 
@@ -94,8 +104,10 @@ def main(argv=sys.argv):
     args = parse_args(argv)
     folder_or_image = args.path
     action = args.app_action
+    train_folder_path = args.train_folder_path
+    test_folder_path = args.test_folder_path
     if action == 'train':
-        train()
+        train(train_folder=train_folder_path, test_folder=test_folder_path)
     elif action == 'predict' and folder_or_image is None:
         print('\n A path to a folder or image is required e.g /hotels or newhotel.jpg \n for help: run python3 app.py -h')
         return

--- a/app.py
+++ b/app.py
@@ -107,7 +107,20 @@ def main(argv=sys.argv):
     train_folder_path = args.train_folder_path
     test_folder_path = args.test_folder_path
     if action == 'train':
-        train(train_folder=train_folder_path, test_folder=test_folder_path)
+        #Check that both train and test folders are present
+        if train_folder_path:
+            # If train folder is provided, test folder must also be provided
+            if test_folder_path:
+                train(train_folder=train_folder_path, test_folder=test_folder_path)
+            print('\n You cannot provide only one folder. Provide training folder and testing folder or None')
+            return #You must return  
+        if test_folder_path:
+            #Means test folder was provided but not train folder
+            print('\n You cannot provide only one folder. Provide training folder and testing folder or None')
+            return #You must return
+        else:
+            # Means no folder was provided, run with default
+            train()
     elif action == 'predict' and folder_or_image is None:
         print('\n A path to a folder or image is required e.g /hotels or newhotel.jpg \n for help: run python3 app.py -h')
         return

--- a/utils/predict_model.py
+++ b/utils/predict_model.py
@@ -3,8 +3,6 @@ import numpy as np
 import keras
 import tensorflow as tf
 from keras.models import load_model
-from IPython.display import display
-from PIL import Image
 from keras.preprocessing import image
 from keras.preprocessing.image import ImageDataGenerator
 from keras.models import Sequential

--- a/utils/train_model.py
+++ b/utils/train_model.py
@@ -40,7 +40,7 @@ def _generator(folder_path =None, is_train_set=True):
     # if is_train_set is False then it's a test data set
     if folder_path is None:
         folder_path = './datasets/test_set'
-    return test_datagen.flow_from_directory(test_folder_path,target_size=(64, 64),
+    return test_datagen.flow_from_directory(test_folder,target_size=(64, 64),
                                                  batch_size=32,
                                                  class_mode='binary')
 

--- a/utils/train_model.py
+++ b/utils/train_model.py
@@ -40,7 +40,7 @@ def _generator(folder_path =None, is_train_set=True):
     # if is_train_set is False then it's a test data set
     if folder_path is None:
         folder_path = './datasets/test_set'
-    return test_datagen.flow_from_directory(test_folder,target_size=(64, 64),
+    return test_datagen.flow_from_directory(folder_path,target_size=(64, 64),
                                                  batch_size=32,
                                                  class_mode='binary')
 

--- a/utils/train_model.py
+++ b/utils/train_model.py
@@ -25,16 +25,37 @@ train_datagen = ImageDataGenerator(
 
 test_datagen = ImageDataGenerator(rescale=1./255)
 
-training_set = train_datagen.flow_from_directory('./datasets/training_set', target_size=(64, 64),
+def _generator(folder_path =None, is_train_set=True):
+    """
+    Accepts a training folder path and generate training set from it.
+
+    if a folder is not supplied, defaults to using ./datasets/training_set
+    """
+    if is_train_set:
+        if folder_path is None:
+            folder_path = './datasets/training_set'
+        return train_datagen.flow_from_directory(folder_path,target_size=(64, 64),
                                                  batch_size=32,
                                                  class_mode='binary')
-test_set = test_datagen.flow_from_directory('./datasets/test_set',
-                                            target_size=(64, 64),
-                                            batch_size=32,
-                                            class_mode='binary')
+    # if is_train_set is False then it's a test data set
+    if folder_path is None:
+        folder_path = './datasets/test_set'
+    return test_datagen.flow_from_directory(test_folder_path,target_size=(64, 64),
+                                                 batch_size=32,
+                                                 class_mode='binary')
+
+
+
+
 resume_weights = "./model/best_weight.h5"
 
-def train( epochs = 100, all_count=10000):
+def train( epochs = 100, all_count=10000, train_folder=None, test_folder=None):
+    
+    #Generate training data set 
+    training_set = _generator(train_folder, is_train_set=True)
+    #Generate test data set
+    test_set = _generator(test_folder, is_train_set=False)
+
     epoch_steps= all_count/ 32
     print("Training")
     classifier = Sequential()
@@ -93,3 +114,4 @@ def setupTF():
     config = tf.ConfigProto(device_count={'GPU': 1})
     sess = tf.Session(config=config)
     keras.backend.set_session(sess)
+


### PR DESCRIPTION
Currently, typing this on command line:

python app.py train
Uses the default datasets to train model. I want to add this :

python app.py train -trp train_path -tep test_path
This will enable us to accept training data folder as well as test data folder.

If we type:

python app.py train
Without specifying any folder, it'll default to using ./datasets/training_set and ./datasets/test_set for training and test data set we provided
if only one folder is provided, it'll not proceed but ask for the remaining folder